### PR TITLE
Allow download of project attachments; fix project attachment display bug; switch to secure jquery URL.

### DIFF
--- a/Project/ProjectDetail.php
+++ b/Project/ProjectDetail.php
@@ -44,7 +44,16 @@ if($projectid != '') {
 		echo '</div></div></div></div>';
 	}
 	
+	$projectmilestoneblock = 'ProjectMilestone';
+	$params = array('id' => "$projectid", 'block'=>"$projectmilestoneblock",'contactid'=>$customerid,'sessionid'=>"$sessionid");
+	$result = $Custom_client->call('get_project_components', $params, $Custom_Server_Path, $Custom_Server_Path);	
+	echo '<div class="widget-box"><div class="widget-header"><h5 class="widget-title">'.getTranslatedString('LBL_PROJECT_MILESTONES').'</h5></div>';
+	echo '<div class = "widget-body"><div class="widget-main no-padding single-entity-view">
+			<div style="width:auto;padding:12px;display:block;" id="tblLeadInformation">';
+	echo getblock_fieldlistview($result,"$projectmilestoneblock");	
+	echo '</table></td></tr>';
 	
+	echo '<tr><td colspan="4">&nbsp;</div></div></div></div>';
 	
 	$projecttaskblock = 'ProjectTask';
 	$params = array('id' => "$projectid", 'block'=>"$projecttaskblock",'contactid'=>$customerid,'sessionid'=>"$sessionid");
@@ -53,17 +62,6 @@ if($projectid != '') {
 	echo '<div class = "widget-body"><div class="widget-main no-padding single-entity-view">
 			<div style="width:auto;padding:12px;display:block;" id="tblLeadInformation">';
 	echo getblock_fieldlistview($result,"$projecttaskblock");	
-	echo '</table></td></tr>';
-	
-	echo '<tr><td colspan="4">&nbsp;</div></div></div></div>';
-	
-	$projectmilestoneblock = 'ProjectMilestone';
-	$params = array('id' => "$projectid", 'block'=>"$projectmilestoneblock",'contactid'=>$customerid,'sessionid'=>"$sessionid");
-	$result = $Custom_client->call('get_project_components', $params, $Custom_Server_Path, $Custom_Server_Path);	
-	echo '<div class="widget-box"><div class="widget-header"><h5 class="widget-title">'.getTranslatedString('LBL_PROJECT_MILESTONES').'</h5></div>';
-	echo '<div class = "widget-body"><div class="widget-main no-padding single-entity-view">
-			<div style="width:auto;padding:12px;display:block;" id="tblLeadInformation">';
-	echo getblock_fieldlistview($result,"$projectmilestoneblock");	
 	echo '</table></td></tr>';
 	
 	echo '<tr><td colspan="4">&nbsp;</div></div></div></div>';

--- a/VTIGER_ROOTDIR/soap/cpvtiger.php
+++ b/VTIGER_ROOTDIR/soap/cpvtiger.php
@@ -1389,7 +1389,7 @@ function get_attachments($input_array)
 			inner join vtiger_crmentity on vtiger_crmentity.crmid=vtiger_notes.notesid 
 			left join vtiger_seattachmentsrel on vtiger_seattachmentsrel.crmid=vtiger_notes.notesid 
 			left join vtiger_attachments on vtiger_attachments.attachmentsid = vtiger_seattachmentsrel.attachmentsid 
-			and vtiger_crmentity.deleted = 0 where vtiger_senotesrel.crmid = ?";
+			where vtiger_crmentity.deleted = 0 and vtiger_senotesrel.crmid = ?";
 
 	$res = $adb->pquery($query, array($blockid));
 	$noofrows = $adb->num_rows($res);

--- a/VTIGER_ROOTDIR/soap/cpvtiger.php
+++ b/VTIGER_ROOTDIR/soap/cpvtiger.php
@@ -2594,16 +2594,14 @@ function get_details($id,$module,$customerid,$sessionid)
 					FROM vtiger_projectmilestone
 					INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = vtiger_projectmilestone.projectmilestoneid
 					LEFT JOIN vtiger_projectmilestonecf ON vtiger_projectmilestonecf.projectmilestoneid = vtiger_projectmilestone.projectmilestoneid
-					WHERE vtiger_projectmilestone.projectmilestoneid = ? AND vtiger_crmentity.deleted =0
-					ORDER BY projectmilestonedate";
+					WHERE vtiger_projectmilestone.projectmilestoneid = ? AND vtiger_crmentity.deleted =0";
 	}
 	else if ($module == 'ProjectTask') {
 		$query = "SELECT vtiger_projecttask.*, vtiger_projecttaskcf.*, vtiger_crmentity.*
 					FROM vtiger_projecttask
 					INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = vtiger_projecttask.projecttaskid
 					LEFT JOIN vtiger_projecttaskcf ON vtiger_projecttaskcf.projecttaskid = vtiger_projecttask.projecttaskid
-					WHERE vtiger_projecttask.projecttaskid = ? AND vtiger_crmentity.deleted = 0
-					ORDER BY enddate";
+					WHERE vtiger_projecttask.projecttaskid = ? AND vtiger_crmentity.deleted = 0";
 	} 
 	
 

--- a/VTIGER_ROOTDIR/soap/cpvtiger.php
+++ b/VTIGER_ROOTDIR/soap/cpvtiger.php
@@ -2594,14 +2594,16 @@ function get_details($id,$module,$customerid,$sessionid)
 					FROM vtiger_projectmilestone
 					INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = vtiger_projectmilestone.projectmilestoneid
 					LEFT JOIN vtiger_projectmilestonecf ON vtiger_projectmilestonecf.projectmilestoneid = vtiger_projectmilestone.projectmilestoneid
-					WHERE vtiger_projectmilestone.projectmilestoneid = ? AND vtiger_crmentity.deleted =0";
+					WHERE vtiger_projectmilestone.projectmilestoneid = ? AND vtiger_crmentity.deleted =0
+					ORDER BY projectmilestonedate";
 	}
 	else if ($module == 'ProjectTask') {
 		$query = "SELECT vtiger_projecttask.*, vtiger_projecttaskcf.*, vtiger_crmentity.*
 					FROM vtiger_projecttask
 					INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = vtiger_projecttask.projecttaskid
 					LEFT JOIN vtiger_projecttaskcf ON vtiger_projecttaskcf.projecttaskid = vtiger_projecttask.projecttaskid
-					WHERE vtiger_projecttask.projecttaskid = ? AND vtiger_crmentity.deleted = 0";
+					WHERE vtiger_projecttask.projecttaskid = ? AND vtiger_crmentity.deleted = 0
+					ORDER BY enddate";
 	} 
 	
 

--- a/footer.html
+++ b/footer.html
@@ -16,7 +16,7 @@
 
 
         <!-- jQuery 2.0.2 -->
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
         <!-- jQuery UI 1.10.3 -->
         <script src="js/jquery-ui-1.10.3.min.js" type="text/javascript"></script>
         <!-- Bootstrap -->

--- a/include/utils/utils.php
+++ b/include/utils/utils.php
@@ -569,7 +569,7 @@ function getblock_fieldAttachments($block, $Custom_client = '', $Custom_Server_P
 											'.$attachments_title.
 										'</label>
 										<div class="col-sm-9 dvtCellInfo" align="left" valign="top">
-											<a href="index.php?downloadfile=true&fileid='.$fileid.'&filename='.$filename.'&filetype='.$filetype.'&filesize='.$filesize.'&id='.$Id.'">'.ltrim($filename,$Id.'_').'</a>
+											<a href="index.php?downloadfile=true&module='.$block.'&fileid='.$fileid.'&filename='.$filename.'&filetype='.$filetype.'&filesize='.$filesize.'&id='.$Id.'">'.ltrim($filename,$Id.'_').'</a>
 										</div>
 									</div>';
 							

--- a/index.php
+++ b/index.php
@@ -36,6 +36,7 @@ include("version.php");
 if($_REQUEST['param'] == 'forgot_password')
 {
 	global $client;
+	global $Custom_client;
 
 	$email = $_REQUEST['email_id'];
 	$params = array('email' => "$email");
@@ -112,6 +113,18 @@ else
 				$block = $_REQUEST['module'];
 				$params = array('id' => "$id", 'folderid'=> "$folderid",'block'=>"$block", 'contactid'=>"$customerid",'sessionid'=>"$sessionid");
 				$result = $client->call('get_filecontent_detail', $params, $Server_Path, $Server_Path);
+				$fileType=$result[0]['filetype'];
+				$filesize=$result[0]['filesize'];
+				$filename=html_entity_decode($result[0]['filename']);
+				$fileContent=$result[0]['filecontents'];
+			}
+			else if(($_REQUEST['module'] == 'Project') or ($_REQUEST['module'] == "ProjectTask"))
+			{
+				$id = $_REQUEST['id'];
+				$block = $_REQUEST['module'];
+				$fileid = $_REQUEST['fileid'];
+				$params = array('id' => "$id", 'fileid' => "$fileid", 'block' => "$block", 'contactid' => "$customerid", 'sessionid' => "$sessionid");
+				$result = $Custom_client->call('get_filecontent_project', $params, $Custom_Server_Path, $Custom_Server_Path);
 				$fileType=$result[0]['filetype'];
 				$filesize=$result[0]['filesize'];
 				$filename=html_entity_decode($result[0]['filename']);


### PR DESCRIPTION
This pull request makes three changes to CPtiger:
1. Updates the jquery URL to use a TLS URL to avoid browser mixed content warnings/restrictions when CPtiger is hosted with TLS.
2. Fixes a bug where deleted project attachments are still displayed by CPtiger with a null fileid.
3. Adds a SOAP API call to the custom CPtiger SOAP API for downloading Project and ProjectTask attachments, as well as the necessary view update and index.php routing to accomplish this.
